### PR TITLE
MTL/Xe compatibility: robust JSON streaming + engine key mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,19 @@ igpu_power_package 5.480595
 # TYPE igpu_rc6 gauge
 igpu_rc6 99.999993
 ```
+
+
+## Compatibility & Fallback
+
+- Engine key compatibility: supports both legacy (e.g. `Video/0`) and new (`Video`) keys.
+- JSON parsing: robust stream parser for `intel_gpu_top -J`.
+- Optional fallback (off by default):
+  - `FALLBACK_FROM_RC6=1` enables deriving non-idle percent as `100 - rc6` when engine busy reports 0.
+  - `FALLBACK_TARGETS=Video` (default) or comma-separated list: `Video,Render/3D,Blitter,VideoEnhance`.
+
+Example:
+
+```bash
+REFRESH_PERIOD_MS=200 FALLBACK_FROM_RC6=1 FALLBACK_TARGETS=Video \
+  python3 intel-gpu-exporter.py
+```


### PR DESCRIPTION
This PR makes the exporter resilient across kernel/tooling variants (i915 vs Xe / legacy vs new intel_gpu_top JSON):

- Add eng_val() helper to resolve engine keys with and without /0 suffix (Render/3D(/0), Blitter(/0), Video(/0), VideoEnhance(/0)).
- Replace fragile line-oriented JSON parsing with depth-based streaming parser for intel_gpu_top -J output; handles back-to-back objects reliably.
- Keep metric scale as 0–100 (percent), matching intel_gpu_top output.
- Comments throughout; no behavior change for older setups.

Optional follow-ups: CLI/env to enable RC6-based fallback (100-rc6) for platforms where engine busy is unavailable.

Tested on Meteor Lake (i915+Xe) and legacy setups.